### PR TITLE
The protected keyword was added

### DIFF
--- a/LoggerPro.pas
+++ b/LoggerPro.pas
@@ -21,10 +21,11 @@ type
     Each call to some kind of log method is wrapped in a @link(TLogItem)
     instance and passed down the layour of LoggerPro. }
   TLogItem = class sealed
+  protected
     constructor Create(aType: TLogType; aMessage: String;
-      aTag: String); overload;
+                       aTag: String); overload;
     constructor Create(aType: TLogType; aMessage: String; aTag: String;
-      aTimeStamp: TDateTime; aThreadID: Cardinal); overload;
+                       aTimeStamp: TDateTime; aThreadID: Cardinal); overload;
   private
     FType: TLogType;
     FMessage: string;


### PR DESCRIPTION
The protected keyword was added because XE8 produces the error "E2266:
Only one of a set of overloaded methods can be published". See:
http://docs.embarcadero.com/products/rad_studio/delphiAndcpp2009/HelpUpdate2/EN/html/devcommon/cm_duplicate_published_xml.html