### PR TITLE
Publish LoggerPro as a package for Delphinus package manager

### DIFF
--- a/Delphinus.Info.json
+++ b/Delphinus.Info.json
@@ -1,0 +1,11 @@
+{
+  "id": "{E35C7797-DC25-4F38-95B7-5D7133D85A2F}",
+  "name": "LoggerPro",
+  "license_type": "Apache 2.0",
+  "license_file": "LICENSE",
+  "platforms": "Win32;Win64",
+  "package_compiler_min": 23,
+  "package_compiler_max": 32,
+  "compiler_min": 23,
+  "compiler_max": 32
+}

--- a/Delphinus.Install.json
+++ b/Delphinus.Install.json
@@ -1,0 +1,25 @@
+{
+  "search_pathes": [{
+    "pathes": ".",
+    "platforms": "Win32;Win64"
+  }],
+  "browsing_pathes": [{
+    "pathes": ".",
+    "platforms": "Win32;Win64"
+  }],
+  "source_folders": [{
+    "folder": "."
+  },
+  {
+    "folder": "docs",
+    "recursive": true
+  },
+  {
+    "folder": "samples",
+    "recursive": true
+  },
+  {
+    "folder": "unittests",
+    "recursive": true
+  }]
+}

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ begin
 end.
 ```
 
-##Built-in log appenders
+## Built-in log appenders
 The framework contains the following built-in log appenders
 - File (`TLoggerProFileAppender`)
 - Console (`TLoggerProConsoleAppender`)
@@ -106,6 +106,9 @@ The log writer and all the appenders are asycnhronous.
 
 **Check the samples to see how to use each appender or even combine different appenders.**
 
-##Documentation
+## Documentation
 
 Documenation is available in the `docs` folder as HTML.
+
+## Other
+You can install [Delphinus package manager](https://github.com/Memnarch/Delphinus/wiki/Installing-Delphinus) and install LoggerPro as a package there. (Delphinus-Support)


### PR DESCRIPTION
It's just a little idea to consider.
Maybe the whole Delphinus project (https://github.com/Memnarch/Delphinus) is not so mature but I think it's just nice idea because it can work directly with GitHub (in opposite to GetIt).

This could also allow to add LoggerPro as a dependency for other Delphinus packages.

The line with keyword "Delphinus-Support" in readme is required to find repository via GitHub API.

Oh... I also fixed headers styling in README.md :wink: 