### PR TITLE
ListView caused error

### DIFF
--- a/LoggerPro.VCLListBoxAppender.pas
+++ b/LoggerPro.VCLListBoxAppender.pas
@@ -1,0 +1,93 @@
+unit LoggerPro.VCLListBoxAppender;
+{ <@abstract(The unit to include if you want to use the @link(TVCLMemoLogAppender))
+  @author(Daniele Teti) }
+
+interface
+
+uses
+  LoggerPro,
+  System.Classes,
+  Vcl.StdCtrls;
+
+type
+  { @abstract(Appends formatted @link(TLogItem) to a TMemo in a VCL application) }
+  TVCLListBoxAppender = class(TLoggerProAppenderBase)
+  private
+    FLB: TListBox;
+    FMaxLogLines: Word;
+    FLogFormat: string;
+  public const
+    { @abstract(Defines the default format string used by the @link(TLoggerProFileAppender).)
+      The positional parameters are the followings:
+      @orderedList(
+      @itemSetNumber 0
+      @item TimeStamp
+      @item ThreadID
+      @item LogType
+      @item LogMessage
+      @item LogTag
+      )
+    }
+    DEFAULT_LOG_FORMAT = '%0:s [TID %1:-8d][%2:-10s] %3:s [%4:s]';
+    constructor Create(aLB: TListBox; aMaxLogLines: Word = 500; aLogFormat: string = DEFAULT_LOG_FORMAT); reintroduce;
+    procedure Setup; override;
+    procedure TearDown; override;
+    procedure WriteLog(const aLogItem: TLogItem); override;
+  end;
+
+implementation
+
+uses
+  System.SysUtils,
+  Winapi.Windows,
+  Winapi.Messages;
+
+{ TVCLMemoLogAppender }
+
+constructor TVCLListBoxAppender.Create(aLB: TListBox; aMaxLogLines: Word; aLogFormat: string);
+begin
+  inherited Create;
+  FLogFormat := aLogFormat;
+  FLB := aLB;
+  FMaxLogLines := aMaxLogLines;
+end;
+
+procedure TVCLListBoxAppender.Setup;
+begin
+  TThread.Synchronize(nil,
+    procedure
+    begin
+      FLB.Clear;
+    end);
+end;
+
+procedure TVCLListBoxAppender.TearDown;
+begin
+  // do nothing
+end;
+
+procedure TVCLListBoxAppender.WriteLog(const aLogItem: TLogItem);
+var
+  lText: string;
+begin
+  lText := Format(FLogFormat, [datetimetostr(aLogItem.TimeStamp), aLogItem.ThreadID, aLogItem.LogTypeAsString,
+    aLogItem.LogMessage, aLogItem.LogTag]);
+  TThread.Queue(nil,
+    procedure
+    var
+      Lines: integer;
+    begin
+      FLB.Items.BeginUpdate;
+      try
+        Lines := FLB.Items.Count;
+        if Lines > FMaxLogLines then
+          FLB.Items.Delete(0);
+        FLB.AddItem(lText, nil)
+      finally
+        FLB.Items.EndUpdate;
+      end;
+      FLB.ItemIndex := FLB.Items.Count - 1;
+    end);
+end;
+
+end.

--- a/LoggerPro.VCLListBoxAppender.pas
+++ b/LoggerPro.VCLListBoxAppender.pas
@@ -1,6 +1,6 @@
 unit LoggerPro.VCLListBoxAppender;
-{ <@abstract(The unit to include if you want to use the @link(TVCLMemoLogAppender))
-  @author(Daniele Teti) }
+{ <@abstract(The unit to include if you want to use the @link(TVCLListBoxAppender))
+  @author(David Cornelius) }
 
 interface
 
@@ -10,7 +10,7 @@ uses
   Vcl.StdCtrls;
 
 type
-  { @abstract(Appends formatted @link(TLogItem) to a TMemo in a VCL application) }
+  { @abstract(Appends formatted @link(TLogItem) to a TListBox in a VCL application) }
   TVCLListBoxAppender = class(TLoggerProAppenderBase)
   private
     FLB: TListBox;
@@ -38,11 +38,9 @@ type
 implementation
 
 uses
-  System.SysUtils,
-  Winapi.Windows,
-  Winapi.Messages;
+  System.SysUtils;
 
-{ TVCLMemoLogAppender }
+{ TVCLListBoxAppender }
 
 constructor TVCLListBoxAppender.Create(aLB: TListBox; aMaxLogLines: Word; aLogFormat: string);
 begin
@@ -82,11 +80,11 @@ begin
         Lines := FLB.Items.Count;
         if Lines > FMaxLogLines then
           FLB.Items.Delete(0);
-        FLB.AddItem(lText, nil)
+        FLB.AddItem(lText, nil);
+        FLB.ItemIndex := FLB.Items.Count - 1;
       finally
         FLB.Items.EndUpdate;
       end;
-      FLB.ItemIndex := FLB.Items.Count - 1;
     end);
 end;
 


### PR DESCRIPTION
I got a report from a customer using an app I built in Delphi 10.3 Rio using the VCLListViewAppender that the app was raising the following error on Windows 7: "Control TListView has no parent window." I had not seen this problem on Windows 8 or 10 and when I replaced the VCLListViewAppender with this new VCLListBoxAppender, the error went away. So I'm submitting this unit for others to use as an option.