### PR TITLE
Fix deadlock in DLL initialization caused by Windows Loader Lock

### DIFF
--- a/LoggerPro.pas
+++ b/LoggerPro.pas
@@ -1021,8 +1021,15 @@ begin
   FLoggerThread := TLoggerThread.Create(FLogAppenders);
   FLoggerThread.EventsHandlers := aEventsHandler;
   FLoggerThread.Start;
-  while not FLoggerThread.Started do
-    Sleep(1); // Wait for thread to actually start
+  if not System.IsLibrary then
+  begin
+    while not FLoggerThread.Started do
+      Sleep(1);
+  end;
+  // When running in a DLL, we skip the spin-wait to avoid a deadlock
+  // caused by the Windows Loader Lock. The queue is already created
+  // in TLoggerThread.Create, so log items can be safely enqueued
+  // before the thread begins executing.
 end;
 
 procedure TCustomLogWriter.Log(const aType: TLogType; const aMessage, aTag: string);


### PR DESCRIPTION
## What:

Skip the thread spin-wait in TCustomLogWriter.Initialize when running inside a DLL.

## Why

When LoggerPro runs in a Delphi DLL loaded by a managed host (e.g. C# via P/Invoke), the while not Started loop deadlocks. The main thread holds the Windows Loader Lock and waits for the logger thread to start, but the new thread cannot execute because it needs DllMain(DLL_THREAD_ATTACH) which requires the same lock.

## How

Guard the spin-wait with System.IsLibrary. When true, skip the wait. This is safe because FQueue is allocated in TLoggerThread.Create before Start, so log items can be enqueued immediately. EXE behavior is unchanged.

## Tests

I've tested it successfully against a C# Application attaching to the Delphi based DLL.
Loading and Logging succeeded.
