### PR TITLE
feat(console): add WithUTF8Output for correct Unicode in Docker and Windows

### DIFF
--- a/LoggerPro.Builder.pas
+++ b/LoggerPro.Builder.pas
@@ -53,12 +53,14 @@ type
     ['{B2C3D4E5-F6A7-5B6C-9D0E-1F2A3B4C5D6E}']
     function WithLogLevel(aLogLevel: TLogType): IConsoleAppenderConfigurator;
     function WithRenderer(aRenderer: ILogItemRenderer): IConsoleAppenderConfigurator;
+    function WithUTF8Output: IConsoleAppenderConfigurator;
   end;
 
   { Simple console appender configurator }
   ISimpleConsoleAppenderConfigurator = interface(IAppenderConfigurator)
     ['{B2C3D4E5-F6A7-5B6C-9D0E-1F2A3B4C5D6F}']
     function WithLogLevel(aLogLevel: TLogType): ISimpleConsoleAppenderConfigurator;
+    function WithUTF8Output: ISimpleConsoleAppenderConfigurator;
   end;
 
   { File appender configurator }
@@ -327,16 +329,22 @@ type
 
   { Console appender configurator }
   TConsoleAppenderConfigurator = class(TBaseAppenderConfigurator, IConsoleAppenderConfigurator)
+  private
+    FUTF8Output: Boolean;
   public
     function WithLogLevel(aLogLevel: TLogType): IConsoleAppenderConfigurator;
     function WithRenderer(aRenderer: ILogItemRenderer): IConsoleAppenderConfigurator;
+    function WithUTF8Output: IConsoleAppenderConfigurator;
     function Done: ILoggerProBuilder;
   end;
 
   { Simple console appender configurator }
   TSimpleConsoleAppenderConfigurator = class(TBaseAppenderConfigurator, ISimpleConsoleAppenderConfigurator)
+  private
+    FUTF8Output: Boolean;
   public
     function WithLogLevel(aLogLevel: TLogType): ISimpleConsoleAppenderConfigurator;
+    function WithUTF8Output: ISimpleConsoleAppenderConfigurator;
     function Done: ILoggerProBuilder;
   end;
 
@@ -960,11 +968,18 @@ begin
   Result := Self;
 end;
 
+function TConsoleAppenderConfigurator.WithUTF8Output: IConsoleAppenderConfigurator;
+begin
+  FUTF8Output := True;
+  Result := Self;
+end;
+
 function TConsoleAppenderConfigurator.Done: ILoggerProBuilder;
 var
   lAppender: ILogAppender;
 begin
   lAppender := TLoggerProConsoleAppender.Create(GetRenderer);
+  (lAppender as TLoggerProConsoleAppender).UTF8Output := FUTF8Output;
   ApplyLogLevel(lAppender);
   FBuilder.InternalAddAppender(lAppender);
   Result := FBuilder;
@@ -979,11 +994,18 @@ begin
   Result := Self;
 end;
 
+function TSimpleConsoleAppenderConfigurator.WithUTF8Output: ISimpleConsoleAppenderConfigurator;
+begin
+  FUTF8Output := True;
+  Result := Self;
+end;
+
 function TSimpleConsoleAppenderConfigurator.Done: ILoggerProBuilder;
 var
   lAppender: ILogAppender;
 begin
   lAppender := TLoggerProSimpleConsoleAppender.Create;
+  (lAppender as TLoggerProSimpleConsoleAppender).UTF8Output := FUTF8Output;
   ApplyLogLevel(lAppender);
   FBuilder.InternalAddAppender(lAppender);
   Result := FBuilder;

--- a/LoggerPro.ConsoleAppender.pas
+++ b/LoggerPro.ConsoleAppender.pas
@@ -51,7 +51,9 @@ type
     class constructor Create;
     class destructor Destroy;
   protected
+    FUTF8Output: Boolean;
 {$IFDEF MSWINDOWS}
+    FSavedOutputCP: Cardinal;
     fColors: array [TLogType.Debug .. TLogType.Fatal] of Integer;
     fSavedColors: Integer;
 {$ELSE}
@@ -60,10 +62,24 @@ type
     procedure SetColor(const aLogType: TLogType);
     procedure ResetColor;
     procedure SetupColorMappings; virtual;
+    /// <summary>
+    /// Writes a line of text as UTF-8 bytes directly to stdout, bypassing Writeln.
+    /// </summary>
+    procedure WriteUTF8Line(const aText: string);
+    /// <summary>
+    /// Writes text as UTF-8 bytes directly to stdout without appending a line break.
+    /// Used for ANSI color escape codes.
+    /// </summary>
+    procedure WriteUTF8Raw(const aText: string);
   public
     procedure Setup; override;
     procedure TearDown; override;
     procedure WriteLog(const aLogItem: TLogItem); override;
+    /// <summary>
+    /// When True, writes UTF-8 bytes directly to stdout instead of using Writeln.
+    /// Prevents Unicode mangling on Linux (POSIX locale) and Windows (console code page).
+    /// </summary>
+    property UTF8Output: Boolean read FUTF8Output write FUTF8Output;
   end;
 
   TLoggerProConsoleLogFmtAppender = class(TLoggerProConsoleAppender)
@@ -77,10 +93,24 @@ type
   /// Uses plain Writeln, works on all platforms (Windows, Linux, macOS).
   /// </summary>
   TLoggerProSimpleConsoleAppender = class(TLoggerProAppenderBase)
+  strict private
+    FUTF8Output: Boolean;
+{$IFDEF MSWINDOWS}
+    FSavedOutputCP: Cardinal;
+{$ENDIF}
+    /// <summary>
+    /// Writes a line of text as UTF-8 bytes directly to stdout, bypassing Writeln.
+    /// </summary>
+    procedure WriteUTF8Line(const aText: string);
   public
     procedure Setup; override;
     procedure TearDown; override;
     procedure WriteLog(const aLogItem: TLogItem); override;
+    /// <summary>
+    /// When True, writes UTF-8 bytes directly to stdout instead of using Writeln.
+    /// Prevents Unicode mangling on Linux (POSIX locale) and Windows (console code page).
+    /// </summary>
+    property UTF8Output: Boolean read FUTF8Output write FUTF8Output;
   end;
 
   TLoggerProSimpleConsoleLogFmtAppender = class(TLoggerProSimpleConsoleAppender)
@@ -98,6 +128,9 @@ implementation
 uses
 {$IFDEF MSWINDOWS}
   Winapi.Windows,
+{$ENDIF}
+{$IFDEF POSIX}
+  Posix.Unistd,
 {$ENDIF}
   LoggerPro.Renderers;
 
@@ -137,6 +170,23 @@ const
   ANSI_RED_BRIGHT = #27'[91m';      // Error
   ANSI_MAGENTA_BRIGHT = #27'[95m';  // Fatal
 {$ENDIF}
+
+procedure InternalWriteUTF8(const aText: string);
+var
+  lBytes: TBytes;
+{$IFDEF MSWINDOWS}
+  lBytesWritten: Cardinal;
+{$ENDIF}
+begin
+  lBytes := TEncoding.UTF8.GetBytes(aText);
+  if Length(lBytes) = 0 then
+    Exit;
+{$IFDEF MSWINDOWS}
+  WriteFile(GetStdHandle(STD_OUTPUT_HANDLE), lBytes[0], Length(lBytes), lBytesWritten, nil);
+{$ELSE}
+  __write(STDOUT_FILENO, @lBytes[0], Length(lBytes));
+{$ENDIF}
+end;
 
 { TLoggerProConsoleAppender }
 
@@ -182,6 +232,11 @@ begin
       FLock.Leave;
     end;
   end;
+  if FUTF8Output then
+  begin
+    FSavedOutputCP := GetConsoleOutputCP;
+    SetConsoleOutputCP(CP_UTF8);
+  end;
 {$ENDIF}
 end;
 
@@ -207,7 +262,10 @@ begin
 {$IFDEF MSWINDOWS}
   SetConsoleTextAttribute(GetStdHandle(STD_OUTPUT_HANDLE), fColors[aLogType]);
 {$ELSE}
-  Write(fColors[aLogType]);
+  if FUTF8Output then
+    WriteUTF8Raw(fColors[aLogType])
+  else
+    Write(fColors[aLogType]);
 {$ENDIF}
 end;
 
@@ -219,7 +277,10 @@ begin
   else
     SetConsoleTextAttribute(GetStdHandle(STD_OUTPUT_HANDLE), FOREGROUND_BLUE or FOREGROUND_GREEN or FOREGROUND_RED);
 {$ELSE}
-  Write(ANSI_RESET);
+  if FUTF8Output then
+    WriteUTF8Raw(ANSI_RESET)
+  else
+    Write(ANSI_RESET);
 {$ENDIF}
 end;
 
@@ -230,6 +291,8 @@ begin
     SetConsoleTextAttribute(GetStdHandle(STD_OUTPUT_HANDLE), fSavedColors)
   else
     SetConsoleTextAttribute(GetStdHandle(STD_OUTPUT_HANDLE), FOREGROUND_BLUE or FOREGROUND_GREEN or FOREGROUND_RED);
+  if FUTF8Output then
+    SetConsoleOutputCP(FSavedOutputCP);
 {$ENDIF}
 end;
 
@@ -241,11 +304,24 @@ begin
   FLock.Enter;
   try
     SetColor(aLogItem.LogType);
-    Writeln(lText);
+    if FUTF8Output then
+      WriteUTF8Line(lText)
+    else
+      Writeln(lText);
     ResetColor;
   finally
     FLock.Leave;
   end;
+end;
+
+procedure TLoggerProConsoleAppender.WriteUTF8Line(const aText: string);
+begin
+  InternalWriteUTF8(aText + sLineBreak);
+end;
+
+procedure TLoggerProConsoleAppender.WriteUTF8Raw(const aText: string);
+begin
+  InternalWriteUTF8(aText);
 end;
 
 { TLoggerProConsoleLogFmtAppender }
@@ -268,16 +344,34 @@ end;
 procedure TLoggerProSimpleConsoleAppender.Setup;
 begin
   inherited;
+{$IFDEF MSWINDOWS}
+  if FUTF8Output then
+  begin
+    FSavedOutputCP := GetConsoleOutputCP;
+    SetConsoleOutputCP(CP_UTF8);
+  end;
+{$ENDIF}
 end;
 
 procedure TLoggerProSimpleConsoleAppender.TearDown;
 begin
-  // nothing to do
+{$IFDEF MSWINDOWS}
+  if FUTF8Output then
+    SetConsoleOutputCP(FSavedOutputCP);
+{$ENDIF}
 end;
 
 procedure TLoggerProSimpleConsoleAppender.WriteLog(const aLogItem: TLogItem);
 begin
-  Writeln(FormatLog(aLogItem));
+  if FUTF8Output then
+    WriteUTF8Line(FormatLog(aLogItem))
+  else
+    Writeln(FormatLog(aLogItem));
+end;
+
+procedure TLoggerProSimpleConsoleAppender.WriteUTF8Line(const aText: string);
+begin
+  InternalWriteUTF8(aText + sLineBreak);
 end;
 
 { TLoggerProSimpleConsoleLogFmtAppender }

--- a/samples/220_utf8_console/Dockerfile
+++ b/samples/220_utf8_console/Dockerfile
@@ -1,0 +1,5 @@
+FROM debian:bookworm-slim
+WORKDIR /app
+COPY utf8_console /app/utf8_console
+RUN chmod +x /app/utf8_console
+CMD ["/app/utf8_console"]

--- a/samples/220_utf8_console/LoggerProConfig.pas
+++ b/samples/220_utf8_console/LoggerProConfig.pas
@@ -1,0 +1,33 @@
+unit LoggerProConfig;
+
+interface
+
+uses
+  LoggerPro;
+
+function Log: ILogWriter;
+
+implementation
+
+uses
+  LoggerPro.ConsoleAppender,
+  LoggerPro.Builder;
+
+var
+  _Log: ILogWriter;
+
+function Log: ILogWriter;
+begin
+  Result := _Log;
+end;
+
+initialization
+
+_Log := LoggerProBuilder
+  .WriteToConsole
+    .WithUTF8Output
+    .WithLogLevel(TLogType.Debug)
+    .Done
+  .Build;
+
+end.

--- a/samples/220_utf8_console/build_linux64.bat
+++ b/samples/220_utf8_console/build_linux64.bat
@@ -1,0 +1,3 @@
+@echo off
+call "C:\Program Files (x86)\Embarcadero\Studio\37.0\bin\rsvars.bat"
+msbuild "%~dp0utf8_console.dproj" /t:Build /p:Config=Debug /p:Platform=Linux64

--- a/samples/220_utf8_console/build_win32.bat
+++ b/samples/220_utf8_console/build_win32.bat
@@ -1,0 +1,3 @@
+@echo off
+call "C:\Program Files (x86)\Embarcadero\Studio\37.0\bin\rsvars.bat"
+msbuild "%~dp0utf8_console.dproj" /t:Build /p:Config=Debug /p:Platform=Win32

--- a/samples/220_utf8_console/docker-compose.yml
+++ b/samples/220_utf8_console/docker-compose.yml
@@ -1,0 +1,4 @@
+services:
+  utf8-console:
+    build: .
+    container_name: loggerpro-utf8-demo

--- a/samples/220_utf8_console/utf8_console.dpr
+++ b/samples/220_utf8_console/utf8_console.dpr
@@ -1,0 +1,55 @@
+program utf8_console;
+
+{$APPTYPE CONSOLE}
+
+{$R *.res}
+
+uses
+  System.SysUtils,
+  LoggerPro,
+  LoggerProConfig in 'LoggerProConfig.pas';
+
+begin
+  try
+    Log.Info('LoggerPro 2.0 - UTF-8 Console Output Demo');
+    Log.Info('==========================================');
+    Log.Info('The Modern, Async, Pluggable Logging Framework for Delphi');
+    Log.Info('Cross-Platform: Windows, Linux, macOS, Android, iOS');
+    Log.Debug('Async by Design - Non-blocking logging with zero impact on performance');
+    Log.Info('20+ Built-in Appenders - File, Console, HTTP, Syslog, ElasticSearch, and more');
+
+    // Unicode: Western European
+    Log.Info('German: Umlaute '#$00C4' '#$00D6' '#$00DC' '#$00DF' - '#$00E4#$00F6#$00FC);
+    Log.Info('French: '#$00E9' '#$00E8' '#$00EA' '#$00EB' - L'#$00E9't'#$00E9' est arriv'#$00E9'e');
+    Log.Info('Italian: Citt'#$00E0' '#$00E8' bella, pi'#$00F9' che mai');
+
+    // Unicode: CJK and other scripts
+    Log.Warn('Japanese: '#$65E5#$672C#$8A9E#$30C6#$30B9#$30C8);
+    Log.Warn('Korean: '#$D55C#$AD6D#$C5B4);
+    Log.Warn('Russian: '#$041F#$0440#$0438#$0432#$0435#$0442);
+
+    // Unicode: Emoji (surrogate pairs)
+    Log.Error('Emoji: '#$D83D#$DE80' '#$D83D#$DCC3' '#$2705' '#$26A1' '#$D83D#$DD25);
+
+    // Structured logging with Unicode context
+    Log.Info('Order completed', 'ORDERS', [
+      LogParam.S('customer', 'M'#$00FC'ller'),
+      LogParam.S('city', 'Z'#$00FC'rich'),
+      LogParam.F('total', 299.99)
+    ]);
+
+    Log.Debug('All UTF-8 tests completed successfully');
+
+{$IFDEF MSWINDOWS}
+    WriteLn;
+    WriteLn('Press Enter to exit...');
+    ReadLn;
+{$ENDIF}
+  except
+    on E: Exception do
+    begin
+      Log.LogException(E, 'Unhandled exception');
+      Writeln(E.ClassName, ': ', E.Message);
+    end;
+  end;
+end.

--- a/samples/220_utf8_console/utf8_console.dproj
+++ b/samples/220_utf8_console/utf8_console.dproj
@@ -1,0 +1,132 @@
+﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <ProjectGuid>{7A8B9C0D-E1F2-4A3B-8C5D-6E7F0A1B2C3D}</ProjectGuid>
+        <MainSource>utf8_console.dpr</MainSource>
+        <Base>True</Base>
+        <Config Condition="'$(Config)'==''">Debug</Config>
+        <ProjectName Condition="'$(ProjectName)'==''">utf8_console</ProjectName>
+        <TargetedPlatforms>129</TargetedPlatforms>
+        <AppType>Console</AppType>
+        <FrameworkType>None</FrameworkType>
+        <ProjectVersion>20.3</ProjectVersion>
+        <Platform Condition="'$(Platform)'==''">Win32</Platform>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Config)'=='Base' or '$(Base)'!=''">
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Android' and '$(Base)'=='true') or '$(Base_Android)'!=''">
+        <Base_Android>true</Base_Android>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Android64' and '$(Base)'=='true') or '$(Base_Android64)'!=''">
+        <Base_Android64>true</Base_Android64>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Linux64' and '$(Base)'=='true') or '$(Base_Linux64)'!=''">
+        <Base_Linux64>true</Base_Linux64>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Win32' and '$(Base)'=='true') or '$(Base_Win32)'!=''">
+        <Base_Win32>true</Base_Win32>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Config)'=='Release' or '$(Cfg_1)'!=''">
+        <Cfg_1>true</Cfg_1>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Config)'=='Debug' or '$(Cfg_2)'!=''">
+        <Cfg_2>true</Cfg_2>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base)'!=''">
+        <DCC_E>false</DCC_E>
+        <DCC_F>false</DCC_F>
+        <DCC_K>false</DCC_K>
+        <DCC_N>false</DCC_N>
+        <DCC_S>false</DCC_S>
+        <DCC_ImageBase>00400000</DCC_ImageBase>
+        <SanitizedProjectName>utf8_console</SanitizedProjectName>
+        <VerInfo_Locale>1040</VerInfo_Locale>
+        <VerInfo_Keys>CompanyName=;FileDescription=;FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductName=;ProductVersion=1.0.0.0;Comments=;CFBundleName=</VerInfo_Keys>
+        <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;$(DCC_Namespace)</DCC_Namespace>
+        <Icon_MainIcon>$(BDS)\bin\delphi_PROJECTICON.ico</Icon_MainIcon>
+        <Icns_MainIcns>$(BDS)\bin\delphi_PROJECTICNS.icns</Icns_MainIcns>
+        <DCC_UnitSearchPath>..\..\;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_Android)'!=''">
+        <VerInfo_Keys>package=com.embarcadero.$(MSBuildProjectName);label=$(MSBuildProjectName);versionCode=1;versionName=1.0.0;persistent=False;restoreAnyVersion=False;installLocation=auto;largeHeap=False;theme=TitleBar;hardwareAccelerated=true;apiKey=;minSdkVersion=23;targetSdkVersion=35</VerInfo_Keys>
+        <BT_BuildType>Debug</BT_BuildType>
+        <EnabledSysJars>activity-1.7.2.dex.jar;annotation-experimental-1.4.1.dex.jar;annotation-jvm-1.8.1.dex.jar;annotations-13.0.dex.jar;appcompat-1.2.0.dex.jar;appcompat-resources-1.2.0.dex.jar;billing-7.1.1.dex.jar;biometric-1.1.0.dex.jar;browser-1.4.0.dex.jar;cloud-messaging.dex.jar;collection-jvm-1.4.2.dex.jar;concurrent-futures-1.1.0.dex.jar;core-1.15.0.dex.jar;core-common-2.2.0.dex.jar;core-ktx-1.15.0.dex.jar;core-runtime-2.2.0.dex.jar;cursoradapter-1.0.0.dex.jar;customview-1.0.0.dex.jar;documentfile-1.0.0.dex.jar;drawerlayout-1.0.0.dex.jar;error_prone_annotations-2.9.0.dex.jar;exifinterface-1.3.6.dex.jar;firebase-annotations-16.2.0.dex.jar;firebase-common-20.3.1.dex.jar;firebase-components-17.1.0.dex.jar;firebase-datatransport-18.1.7.dex.jar;firebase-encoders-17.0.0.dex.jar;firebase-encoders-json-18.0.0.dex.jar;firebase-encoders-proto-16.0.0.dex.jar;firebase-iid-interop-17.1.0.dex.jar;firebase-installations-17.1.3.dex.jar;firebase-installations-interop-17.1.0.dex.jar;firebase-measurement-connector-19.0.0.dex.jar;firebase-messaging-23.1.2.dex.jar;fmx.dex.jar;fragment-1.2.5.dex.jar;google-play-licensing.dex.jar;interpolator-1.0.0.dex.jar;javax.inject-1.dex.jar;kotlin-stdlib-1.8.22.dex.jar;kotlin-stdlib-common-1.8.22.dex.jar;kotlin-stdlib-jdk7-1.8.22.dex.jar;kotlin-stdlib-jdk8-1.8.22.dex.jar;kotlinx-coroutines-android-1.6.4.dex.jar;kotlinx-coroutines-core-jvm-1.6.4.dex.jar;legacy-support-core-utils-1.0.0.dex.jar;lifecycle-common-2.6.2.dex.jar;lifecycle-livedata-2.6.2.dex.jar;lifecycle-livedata-core-2.6.2.dex.jar;lifecycle-runtime-2.6.2.dex.jar;lifecycle-service-2.6.2.dex.jar;lifecycle-viewmodel-2.6.2.dex.jar;lifecycle-viewmodel-savedstate-2.6.2.dex.jar;listenablefuture-1.0.dex.jar;loader-1.0.0.dex.jar;localbroadcastmanager-1.0.0.dex.jar;okio-jvm-3.4.0.dex.jar;play-services-ads-22.2.0.dex.jar;play-services-ads-base-22.2.0.dex.jar;play-services-ads-identifier-18.0.0.dex.jar;play-services-ads-lite-22.2.0.dex.jar;play-services-appset-16.0.1.dex.jar;play-services-base-18.5.0.dex.jar;play-services-basement-18.4.0.dex.jar;play-services-cloud-messaging-17.0.1.dex.jar;play-services-location-21.0.1.dex.jar;play-services-maps-18.1.0.dex.jar;play-services-measurement-base-20.1.2.dex.jar;play-services-measurement-sdk-api-20.1.2.dex.jar;play-services-stats-17.0.2.dex.jar;play-services-tasks-18.2.0.dex.jar;print-1.0.0.dex.jar;profileinstaller-1.3.0.dex.jar;room-common-2.2.5.dex.jar;room-runtime-2.2.5.dex.jar;savedstate-1.2.1.dex.jar;sqlite-2.1.0.dex.jar;sqlite-framework-2.1.0.dex.jar;startup-runtime-1.1.1.dex.jar;tracing-1.2.0.dex.jar;transport-api-3.0.0.dex.jar;transport-backend-cct-3.1.8.dex.jar;transport-runtime-3.1.8.dex.jar;user-messaging-platform-2.0.0.dex.jar;vectordrawable-1.1.0.dex.jar;vectordrawable-animated-1.1.0.dex.jar;versionedparcelable-1.1.1.dex.jar;viewpager-1.0.0.dex.jar;work-runtime-2.7.0.dex.jar</EnabledSysJars>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_Android64)'!=''">
+        <VerInfo_Keys>package=com.embarcadero.$(MSBuildProjectName);label=$(MSBuildProjectName);versionCode=1;versionName=1.0.0;persistent=False;restoreAnyVersion=False;installLocation=auto;largeHeap=False;theme=TitleBar;hardwareAccelerated=true;apiKey=;minSdkVersion=23;targetSdkVersion=35</VerInfo_Keys>
+        <BT_BuildType>Debug</BT_BuildType>
+        <EnabledSysJars>activity-1.7.2.dex.jar;annotation-experimental-1.4.1.dex.jar;annotation-jvm-1.8.1.dex.jar;annotations-13.0.dex.jar;appcompat-1.2.0.dex.jar;appcompat-resources-1.2.0.dex.jar;billing-7.1.1.dex.jar;biometric-1.1.0.dex.jar;browser-1.4.0.dex.jar;cloud-messaging.dex.jar;collection-jvm-1.4.2.dex.jar;concurrent-futures-1.1.0.dex.jar;core-1.15.0.dex.jar;core-common-2.2.0.dex.jar;core-ktx-1.15.0.dex.jar;core-runtime-2.2.0.dex.jar;cursoradapter-1.0.0.dex.jar;customview-1.0.0.dex.jar;documentfile-1.0.0.dex.jar;drawerlayout-1.0.0.dex.jar;error_prone_annotations-2.9.0.dex.jar;exifinterface-1.3.6.dex.jar;firebase-annotations-16.2.0.dex.jar;firebase-common-20.3.1.dex.jar;firebase-components-17.1.0.dex.jar;firebase-datatransport-18.1.7.dex.jar;firebase-encoders-17.0.0.dex.jar;firebase-encoders-json-18.0.0.dex.jar;firebase-encoders-proto-16.0.0.dex.jar;firebase-iid-interop-17.1.0.dex.jar;firebase-installations-17.1.3.dex.jar;firebase-installations-interop-17.1.0.dex.jar;firebase-measurement-connector-19.0.0.dex.jar;firebase-messaging-23.1.2.dex.jar;fmx.dex.jar;fragment-1.2.5.dex.jar;google-play-licensing.dex.jar;interpolator-1.0.0.dex.jar;javax.inject-1.dex.jar;kotlin-stdlib-1.8.22.dex.jar;kotlin-stdlib-common-1.8.22.dex.jar;kotlin-stdlib-jdk7-1.8.22.dex.jar;kotlin-stdlib-jdk8-1.8.22.dex.jar;kotlinx-coroutines-android-1.6.4.dex.jar;kotlinx-coroutines-core-jvm-1.6.4.dex.jar;legacy-support-core-utils-1.0.0.dex.jar;lifecycle-common-2.6.2.dex.jar;lifecycle-livedata-2.6.2.dex.jar;lifecycle-livedata-core-2.6.2.dex.jar;lifecycle-runtime-2.6.2.dex.jar;lifecycle-service-2.6.2.dex.jar;lifecycle-viewmodel-2.6.2.dex.jar;lifecycle-viewmodel-savedstate-2.6.2.dex.jar;listenablefuture-1.0.dex.jar;loader-1.0.0.dex.jar;localbroadcastmanager-1.0.0.dex.jar;okio-jvm-3.4.0.dex.jar;play-services-ads-22.2.0.dex.jar;play-services-ads-base-22.2.0.dex.jar;play-services-ads-identifier-18.0.0.dex.jar;play-services-ads-lite-22.2.0.dex.jar;play-services-appset-16.0.1.dex.jar;play-services-base-18.5.0.dex.jar;play-services-basement-18.4.0.dex.jar;play-services-cloud-messaging-17.0.1.dex.jar;play-services-location-21.0.1.dex.jar;play-services-maps-18.1.0.dex.jar;play-services-measurement-base-20.1.2.dex.jar;play-services-measurement-sdk-api-20.1.2.dex.jar;play-services-stats-17.0.2.dex.jar;play-services-tasks-18.2.0.dex.jar;print-1.0.0.dex.jar;profileinstaller-1.3.0.dex.jar;room-common-2.2.5.dex.jar;room-runtime-2.2.5.dex.jar;savedstate-1.2.1.dex.jar;sqlite-2.1.0.dex.jar;sqlite-framework-2.1.0.dex.jar;startup-runtime-1.1.1.dex.jar;tracing-1.2.0.dex.jar;transport-api-3.0.0.dex.jar;transport-backend-cct-3.1.8.dex.jar;transport-runtime-3.1.8.dex.jar;user-messaging-platform-2.0.0.dex.jar;vectordrawable-1.1.0.dex.jar;vectordrawable-animated-1.1.0.dex.jar;versionedparcelable-1.1.1.dex.jar;viewpager-1.0.0.dex.jar;work-runtime-2.7.0.dex.jar</EnabledSysJars>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_Linux64)'!=''">
+        <BT_BuildType>Debug</BT_BuildType>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_Win32)'!=''">
+        <DCC_Namespace>Winapi;System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;Bde;$(DCC_Namespace)</DCC_Namespace>
+        <BT_BuildType>Debug</BT_BuildType>
+        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
+        <VerInfo_Locale>1033</VerInfo_Locale>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_1)'!=''">
+        <DCC_Define>RELEASE;$(DCC_Define)</DCC_Define>
+        <DCC_DebugInformation>0</DCC_DebugInformation>
+        <DCC_LocalDebugSymbols>false</DCC_LocalDebugSymbols>
+        <DCC_SymbolReferenceInfo>0</DCC_SymbolReferenceInfo>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_2)'!=''">
+        <DCC_Define>DEBUG;$(DCC_Define)</DCC_Define>
+        <DCC_Optimize>false</DCC_Optimize>
+        <DCC_GenerateStackFrames>true</DCC_GenerateStackFrames>
+        <DCC_RangeChecking>true</DCC_RangeChecking>
+        <DCC_IntegerOverflowCheck>true</DCC_IntegerOverflowCheck>
+    </PropertyGroup>
+    <ItemGroup>
+        <DelphiCompile Include="$(MainSource)">
+            <MainSource>MainSource</MainSource>
+        </DelphiCompile>
+        <DCCReference Include="LoggerProConfig.pas"/>
+        <BuildConfiguration Include="Base">
+            <Key>Base</Key>
+        </BuildConfiguration>
+        <BuildConfiguration Include="Release">
+            <Key>Cfg_1</Key>
+            <CfgParent>Base</CfgParent>
+        </BuildConfiguration>
+        <BuildConfiguration Include="Debug">
+            <Key>Cfg_2</Key>
+            <CfgParent>Base</CfgParent>
+        </BuildConfiguration>
+    </ItemGroup>
+    <ProjectExtensions>
+        <Borland.Personality>Delphi.Personality.12</Borland.Personality>
+        <Borland.ProjectType/>
+        <BorlandProject>
+            <Delphi.Personality>
+                <Source>
+                    <Source Name="MainSource">utf8_console.dpr</Source>
+                </Source>
+            </Delphi.Personality>
+            <Platforms>
+                <Platform value="Android">False</Platform>
+                <Platform value="Android64">False</Platform>
+                <Platform value="Linux64">True</Platform>
+                <Platform value="Win32">True</Platform>
+                <Platform value="Win64">False</Platform>
+            </Platforms>
+        </BorlandProject>
+        <ProjectFileVersion>12</ProjectFileVersion>
+    </ProjectExtensions>
+    <Import Project="$(BDS)\Bin\CodeGear.Delphi.Targets" Condition="Exists('$(BDS)\Bin\CodeGear.Delphi.Targets')"/>
+    <Import Project="$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj" Condition="Exists('$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj')"/>
+</Project>

--- a/unittests/BuilderTestU.pas
+++ b/unittests/BuilderTestU.pas
@@ -88,6 +88,10 @@ type
     procedure TestWriteToStringsWithMaxLines;
     [Test]
     procedure TestWriteToStringsClearOnStartup;
+    [Test]
+    procedure TestBuildWithConsoleUTF8Output;
+    [Test]
+    procedure TestBuildWithSimpleConsoleUTF8Output;
 {$IF Defined(MSWINDOWS)}
     [Test]
     procedure TestWriteToWindowsEventLog;
@@ -1166,6 +1170,28 @@ begin
     lLog := nil;
     lStrings.Free;
   end;
+end;
+
+procedure TLoggerProBuilderTest.TestBuildWithConsoleUTF8Output;
+var
+  lLog: ILogWriter;
+begin
+  lLog := LoggerProBuilder
+    .WriteToConsole.WithUTF8Output.Done
+    .Build;
+
+  Assert.IsNotNull(lLog, 'Logger should be created with UTF8 console appender');
+end;
+
+procedure TLoggerProBuilderTest.TestBuildWithSimpleConsoleUTF8Output;
+var
+  lLog: ILogWriter;
+begin
+  lLog := LoggerProBuilder
+    .WriteToSimpleConsole.WithUTF8Output.Done
+    .Build;
+
+  Assert.IsNotNull(lLog, 'Logger should be created with UTF8 simple console appender');
 end;
 
 {$IF Defined(MSWINDOWS)}


### PR DESCRIPTION
## What

- Add WithUTF8Output builder option to WriteToConsole and WriteToSimpleConsole
- When enabled, writes UTF-8 bytes directly to stdout instead of using Delphi's Writeln
- New sample project 220_utf8_console with Dockerfile for testing in containers

## Why

Delphi's Writeln converts UTF-16 strings to the system locale encoding. In Docker containers (POSIX/C locale) this mangles all non-ASCII characters. On Windows, the console codepage (CP 437/1252) drops characters outside that range. Writing UTF-8 bytes directly to stdout fixes both cases.

## How

- LoggerPro.ConsoleAppender.pas: Added InternalWriteUTF8 unit-level helper that encodes to UTF-8 and writes via WriteFile (Windows) or __write (POSIX). Both appender classes
  delegate to it. On Windows, SetConsoleOutputCP(CP_UTF8) is set in Setup and restored in TearDown.
- LoggerPro.Builder.pas: Added WithUTF8Output to both console configurator interfaces and implementations. Default is off (backward compatible).

## Tests
- TestBuildWithConsoleUTF8Output and TestBuildWithSimpleConsoleUTF8Output in BuilderTestU.pas
- Manual verification: compile sample for Win32, run locally. Cross-compile for Linux64, docker compose up --build to verify Unicode in docker logs.

## Environment

- Delphi 12.2+ (tested with 12.3 Florence)
- Target platforms: Win32, Win64, Linux64
- No new dependencies

## Screenshots

### Windows Console: 

<img width="1374" height="351" alt="UTF8-Console" src="https://github.com/user-attachments/assets/3e3535b1-b785-47ca-aa18-4759e00116d6" />

### Docker Log

<img width="1628" height="424" alt="UTF8-Docker" src="https://github.com/user-attachments/assets/3aa9447e-a149-4dfb-8cf6-33d9d494a2c7" />

